### PR TITLE
Add mat4:send(): Returns a temporary table for Shader:send

### DIFF
--- a/modules/mat4.lua
+++ b/modules/mat4.lua
@@ -319,6 +319,20 @@ function mat4.clone(a)
 	return new(a)
 end
 
+local matrix = {}
+--- Returns a table with the matrix that you can then send through shader:send safely
+-- @tparam mat4 a Matrix to turn into a table
+-- @treturn table out
+function mat4.send(a)
+	if type(m) == "table" then return m end
+
+	for i=1, 16 do
+		matrix[i]=m[i]
+	end
+
+	return matrix
+end
+
 --- Multiply two matrices.
 -- @tparam mat4 out Matrix to store the result
 -- @tparam mat4 a Left hand operand


### PR DESCRIPTION
This specifically useful when FFI is in use and you need to send the matrix, some other APIs like vecs could also benefit from a similar method.

This operation doesn't guarantee uniqueness of the table or that it won't be altered at a later point, it should only be used in combination with Shader:send and the returned value shouldn't be assigned to other variables since it's subject to be mutated.

Note that this is only one way to approach the problem so fill free to review and ask for changes, I have found this works for my use case (and allows me to safely enable FFI)