### PR TITLE
Remove DO_THRESHOLD check from quat.pow

### DIFF
--- a/modules/quat.lua
+++ b/modules/quat.lua
@@ -177,10 +177,6 @@ function quat.pow(a, s)
 	end
 	local dot = a.w
 
-	if dot > DOT_THRESHOLD then
-		return a:scale(s)
-	end
-
 	dot = min(max(dot, -1), 1)
 
 	local theta = acos(dot) * s


### PR DESCRIPTION
In discussion with @shakesoda it was concluded these four lines were copypasted accidentally from lerp(). Fixes #43