### PR TITLE
to_string methods for bound2 and bound3

### DIFF
--- a/modules/bound2.lua
+++ b/modules/bound2.lua
@@ -152,6 +152,13 @@ function bound2.contains(a, v)
 	   and a.max.x >= v.x and a.max.y >= v.y
 end
 
+--- Return a formatted string.
+-- @tparam bound2 a bound to be turned into a string
+-- @treturn string formatted
+function bound2.to_string(a)
+	return string.format("(%s-%s)", a.min, a.max)
+end
+
 bound2_mt.__index    = bound2
 bound2_mt.__tostring = bound2.to_string
 

--- a/modules/bound3.lua
+++ b/modules/bound3.lua
@@ -152,6 +152,13 @@ function bound3.contains(a, v)
 	   and a.max.x >= v.x and a.max.y >= v.y and a.max.z >= v.z
 end
 
+--- Return a formatted string.
+-- @tparam bound3 a bound to be turned into a string
+-- @treturn string formatted
+function bound3.to_string(a)
+	return string.format("(%s-%s)", a.min, a.max)
+end
+
 bound3_mt.__index    = bound3
 bound3_mt.__tostring = bound3.to_string
 


### PR DESCRIPTION
So for example
```
print(bound2.at(vec2(1,1), vec2(3,3)))
print(bound3.at(vec3(1,1,1), vec3(3,3,3)))
```
prints
```
((+1.000,+1.000)-(+3.000,+3.000))
((+1.000,+1.000,+1.000)-(+3.000,+3.000,+3.000))
```