### PR TITLE
Make vec2(vec2(1,2)) and vec3(vec3(1,2,3)) consistent between lua/luajit

### DIFF
--- a/modules/vec2.lua
+++ b/modules/vec2.lua
@@ -54,7 +54,7 @@ function vec2.new(x, y)
 		return new(x, y)
 
 	-- {x, y} or {x=x, y=y}
-	elseif type(x) == "table" then
+	elseif type(x) == "table" or type(x) == "cdata" then -- table in vanilla lua, cdata in luajit
 		local xx, yy = x.x or x[1], x.y or x[2]
 		assert(type(xx) == "number", "new: Wrong argument type for x (<number> expected)")
 		assert(type(yy) == "number", "new: Wrong argument type for y (<number> expected)")

--- a/modules/vec3.lua
+++ b/modules/vec3.lua
@@ -55,7 +55,7 @@ function vec3.new(x, y, z)
 		return new(x, y, z)
 
 	-- {x, y, z} or {x=x, y=y, z=z}
-	elseif type(x) == "table" then
+	elseif type(x) == "table" or type(x) == "cdata" then -- table in vanilla lua, cdata in luajit
 		local xx, yy, zz = x.x or x[1], x.y or x[2], x.z or x[3]
 		assert(type(xx) == "number", "new: Wrong argument type for x (<number> expected)")
 		assert(type(yy) == "number", "new: Wrong argument type for y (<number> expected)")

--- a/spec/vec2_spec.lua
+++ b/spec/vec2_spec.lua
@@ -41,6 +41,12 @@ describe("vec2:", function()
 		assert.is.equal(a, b)
 	end)
 
+	it("clones a vector using the constructor", function()
+		local a = vec2(3, 5)
+		local b = vec2(a)
+		assert.is.equal(a, b)
+	end)
+
 	it("adds a vector to another", function()
 		local a = vec2(3, 5)
 		local b = vec2(7, 4)
@@ -181,5 +187,14 @@ describe("vec2:", function()
 		local a = vec2()
 		local b = a:to_string()
 		assert.is.equal("(+0.000,+0.000)", b)
+	end)
+
+	-- Do this last, to insulate tests from accidental state contamination
+	it("converts a vec3 to vec2 using the constructor", function()
+		local vec3 = require "modules.vec3"
+		local a = vec2(3, 5)
+		local b = vec3(3, 5, 7)
+		local c = vec2(b)
+		assert.is.equal(a, c)
 	end)
 end)

--- a/spec/vec3_spec.lua
+++ b/spec/vec3_spec.lua
@@ -46,6 +46,12 @@ describe("vec3:", function()
 		assert.is.equal(a, b)
 	end)
 
+	it("clones a vector using the constructor", function()
+		local a = vec3(3, 5, 7)
+		local b = vec3(a)
+		assert.is.equal(a, b)
+	end)
+
 	it("adds a vector to another", function()
 		local a = vec3(3, 5, 7)
 		local b = vec3(7, 4, 1)


### PR DESCRIPTION
Consider this code
```
local a = vec2(1,2)
local b = vec3(3,4,5)
local c = vec2(a)
local d = vec2(b)
local e = vec3(b)
print(a,b,c,d,e)
```
On Lua, this will print
```
(+1.000,+2.000)	(+3.000,+4.000,+5.000)	(+1.000,+2.000)	(+3.000,+4.000)	(+3.000,+4.000,+5.000)
```
On LuaJIT, b, d and e will be converted to (0,0,0). This is because the "table" check in the vec2 and vec3 constructors do not match vec2 and vec3 themselves, because they are CDATAs in LuaJIT.

I'm not sure clone-by-constructor is a good feature, I prefer `:clone()`, but if it's going to exist it should at least be consistent between Lua and LuaJIT.