### PR TITLE
Automate ldoc generation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+# Based on https://gist.github.com/domenic/ec8b0fc8ab45f39403dd
+name: Documentation
+
+on:
+  pull_request: # Build on pull requests to ensure they don't break docs.
+    branches:
+    - master
+  push:         # We'll only push new docs when master is updated (see below).
+    branches:
+    - master
+
+jobs:
+  build:
+    name: Build Docs
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Lua
+      uses: leafo/gh-actions-lua@v8
+      with:
+        luaVersion: 5.4
+    - name: Setup Lua Rocks
+      uses: leafo/gh-actions-luarocks@v4
+    - name: Setup and run ldoc
+      run: bash ./doc/install_and_build_docs
+    - name: Deploy
+      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./doc/out

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 # LDoc generated files.
-doc/doc
+doc/out

--- a/doc/config.ld
+++ b/doc/config.ld
@@ -7,3 +7,6 @@ file = {
    "../init.lua",
    "../modules"
 }
+dir='./out'
+readme='../README.md'
+style='!new'

--- a/doc/install_and_build_docs
+++ b/doc/install_and_build_docs
@@ -1,0 +1,13 @@
+#! /bin/sh
+
+# on github, leafo/gh-actions-lua leafo/gh-actions-luarocks setup luarocks for us.
+#~ sudo apt-get install lua5.3 liblua5.3-dev luarocks
+
+# github ldoc is far ahead of the released version.
+echo ldoc version:
+git ls-remote https://github.com/lunarmodules/LDoc master
+luarocks --local install https://raw.githubusercontent.com/lunarmodules/LDoc/master/ldoc-scm-3.rockspec
+
+echo
+cd ./doc
+~/.luarocks/bin/ldoc .


### PR DESCRIPTION
#11 mentioned using github actions to generate docs. I did that on some of my repos recently so I thought I'd contribute the same change here. This also introduces the install_and_build_docs script which will install ldoc and build the docs.

Quick version: After every push to master, it will generate docs to gh-pages so they [look like this](https://idbrii.github.io/love-cpml/).

---


Builds docs to the gh-pages branch on every push to master. Also updates
all dead links to point to live ones (or ones that will be live after
this is merged).

Uses three third-party gh actions:

* leafo/gh-actions-lua@v8
* leafo/gh-actions-luarocks@v4
* peaceiris/actions-gh-pages@v3
  * This one receives secrets.GITHUB_TOKEN

Also switches to the new ldoc css and moves doc output folder to
./doc/out which is less confusing when configuring than ./doc/doc.

Once merged, docs will be available on https://excessive.github.io/cpml/

Currently, you can see the built docs on https://idbrii.github.io/love-cpml/