### PR TITLE
Fix index nil error in private.round

### DIFF
--- a/modules/_private_utils.lua
+++ b/modules/_private_utils.lua
@@ -5,7 +5,7 @@ local floor   = math.floor
 local ceil    = math.ceil
 
 function private.round(value, precision)
-	if precision then return utils.round(value / precision) * precision end
+	if precision then return private.round(value / precision) * precision end
 	return value >= 0 and floor(value+0.5) or ceil(value-0.5)
 end
 

--- a/spec/utils_spec.lua
+++ b/spec/utils_spec.lua
@@ -27,6 +27,18 @@ describe("utils:", function()
 		local v = utils.decay(0, 1, 0.5, 1)
 		assert.is_true(tolerance(v, 0.39346934028737))
 	end)
+
+	it("rounds a number", function()
+		-- round up
+		local v = utils.round(1.3252525, 0.01)
+		assert.is_true(tolerance(v, 1.33))
+		-- round down
+		v = utils.round(1.3242525, 0.1)
+		assert.is_true(tolerance(v, 1.3))
+		-- no precision
+		v = utils.round(1.3242525)
+		assert.is_true(tolerance(v, 1))
+	end)
 end)
 
 --[[
@@ -37,7 +49,6 @@ tolerance(value, threshold)
 map(value, min_in, max_in, min_out, max_out)
 lerp(progress, low, high)
 smoothstep(progress, low, high)
-round(value, precision)
 wrap(value, limit)
 is_pot(value)
 project_on(out, a, b)


### PR DESCRIPTION
Fix "Error: src/lib/cpml/modules/_private_utils.lua:8: attempt to index
    global 'utils' (a nil value)"

Looks like when round was moved to _private_utils, this didn't get
replaced. There is no utils defined and utils.round just points to
private.round. Reference private.round instead of util.round.

Add a test. This error never triggered test failures because test didn't pass precision.
    

Tested in love2d with main.lua:

    local Vec2 = require "cpml.modules.vec2"
    local v = Vec2(1.234, 3.5326)
    print(v:round(0.1))

    local utils = require "cpml.modules.utils"
    local function tolerance(v, t)
        return math.abs(v - t) < 1e-6
    end
    local x = utils.round(1.3252525, 0.01)
    assert(tolerance(x, 1.33))
    x = utils.round(1.3242525, 0.1)
    assert(tolerance(x, 1.3))
    x = utils.round(1.3242525)
    assert(tolerance(x, 1))

