### PR TITLE
Switch build badge to github actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Cirno's Perfect Math Library
 ====
 
-[![Build Status](https://travis-ci.com/excessive/cpml.svg?branch=master)](https://travis-ci.com/excessive/cpml)
+![Build Status](https://github.com/excessive/cpml/actions/workflows/runtest.yml/badge.svg)
 [![Coverage Status](https://coveralls.io/repos/github/excessive/cpml/badge.svg?branch=master)](https://coveralls.io/github/excessive/cpml?branch=master)
 
 Various useful bits of game math. 3D line intersections, ray casting, 2d/3d vectors, 4x4 matrices, quaternions, etc.


### PR DESCRIPTION
We don't use travis anymore, so point the readme to the right badge.

(Missed in 84ff1b315e691069389ebbd7e1abcc054e1987ab.)