### PR TITLE
Rename normalize -> normalized; Additionally return length from normalized

### DIFF
--- a/modules/intersect.lua
+++ b/modules/intersect.lua
@@ -181,7 +181,7 @@ end
 -- aabb.min      is a vec3
 -- aabb.max      is a vec3
 function intersect.ray_aabb(ray, aabb)
-	local dir     = ray.direction:normalize()
+	local dir     = ray.direction:normalized()
 	local dirfrac = vec3(
 		1 / dir.x,
 		1 / dir.y,

--- a/modules/mat4.lua
+++ b/modules/mat4.lua
@@ -136,9 +136,9 @@ end
 -- @tparam vec3 up Up direction
 -- @treturn mat4 out
 function mat4.from_direction(direction, up)
-	local forward = vec3.normalize(direction)
-	local side = vec3.cross(forward, up):normalize()
-	local new_up = vec3.cross(side, forward):normalize()
+	local forward = vec3.normalized(direction)
+	local side = vec3.cross(forward, up):normalized()
+	local new_up = vec3.cross(side, forward):normalized()
 
 	local out = new()
 	out[1]    = side.x
@@ -528,8 +528,8 @@ end
 -- @tparam vec3 up Up direction
 -- @treturn mat4 out
 function mat4.look_at(out, a, eye, look_at, up)
-	local z_axis = (eye - look_at):normalize()
-	local x_axis = up:cross(z_axis):normalize()
+	local z_axis = (eye - look_at):normalized()
+	local x_axis = up:cross(z_axis):normalized()
 	local y_axis = z_axis:cross(x_axis)
 	out[1] = x_axis.x
 	out[2] = y_axis.x
@@ -718,7 +718,7 @@ function mat4.to_quat(a)
 		w
 	)
 
-	return q:normalize(q)
+	return q:normalized(q)
 end
 
 -- http://www.crownandcutlass.com/features/technicaldetails/frustum.html

--- a/modules/mesh.lua
+++ b/modules/mesh.lua
@@ -20,7 +20,7 @@ end
 function mesh.normal(triangle)
 	local ba = triangle[2] - triangle[1]
 	local ca = triangle[3] - triangle[1]
-	return ba:cross(ca):normalize()
+	return ba:cross(ca):normalized()
 end
 
 -- triangle[1] is a vec3

--- a/modules/quat.lua
+++ b/modules/quat.lua
@@ -103,7 +103,7 @@ end
 -- @treturn quat out
 function quat.from_direction(normal, up)
 	local u = up or vec3.unit_z
-	local n = normal:normalize()
+	local n = normal:normalized()
 	local a = u:cross(n)
 	local d = u:dot(n)
 	return new(a.x, a.y, a.z, d + 1)
@@ -182,7 +182,7 @@ function quat.pow(a, s)
 	dot = min(max(dot, -1), 1)
 
 	local theta = acos(dot) * s
-	local c = new(a.x, a.y, a.z, 0):normalize() * sin(theta)
+	local c = new(a.x, a.y, a.z, 0):normalized() * sin(theta)
 	c.w = cos(theta)
 	return c
 end
@@ -190,7 +190,7 @@ end
 --- Normalize a quaternion.
 -- @tparam quat a Quaternion to normalize
 -- @treturn quat out
-function quat.normalize(a)
+function quat.normalized(a)
 	if a:is_zero() then
 		return new(0, 0, 0, 0)
 	end
@@ -257,7 +257,7 @@ function quat.inverse(a)
 	tmp.y = -a.y
 	tmp.z = -a.z
 	tmp.w =  a.w
-	return tmp:normalize()
+	return tmp:normalized()
 end
 
 --- Return the reciprocal of a quaternion.
@@ -283,7 +283,7 @@ end
 -- @tparam number s Step value
 -- @treturn quat out
 function quat.lerp(a, b, s)
-	return (a + (b - a) * s):normalize()
+	return (a + (b - a) * s):normalized()
 end
 
 --- Slerp between two quaternions.
@@ -306,7 +306,7 @@ function quat.slerp(a, b, s)
 	dot = min(max(dot, -1), 1)
 
 	local theta = acos(dot) * s
-	local c = (b - a * dot):normalize()
+	local c = (b - a * dot):normalized()
 	return a * cos(theta) + c * sin(theta)
 end
 
@@ -383,7 +383,7 @@ end
 -- @treturn z axis-z
 function quat.to_angle_axis_unpack(a, identityAxis)
 	if a.w > 1 or a.w < -1 then
-		a = a:normalize()
+		a = a:normalized()
 	end
 
 	-- If length of xyz components is less than DBL_EPSILON, this is zero or close enough (an identity quaternion)

--- a/modules/quat.lua
+++ b/modules/quat.lua
@@ -187,15 +187,18 @@ function quat.pow(a, s)
 	return c
 end
 
---- Normalize a quaternion.
+--- Get the unit and length for a quaternion.
 -- @tparam quat a Quaternion to normalize
 -- @treturn quat out
+-- @treturn number length
 function quat.normalized(a)
 	if a:is_zero() then
-		return new(0, 0, 0, 0)
+		return new(0, 0, 0, 0), 0
 	end
-	return a:scale(1 / a:len())
+	local len = a:len()
+	return a:scale(1 / len), len
 end
+
 
 --- Get the dot product of two quaternions.
 -- @tparam quat a Left hand operand

--- a/modules/vec2.lua
+++ b/modules/vec2.lua
@@ -134,14 +134,16 @@ function vec2.div(a, b)
 	)
 end
 
---- Get the unit vector for a vector.
+--- Get the unit vector and length for a vector.
 -- @tparam vec2 a Vector to normalize
 -- @treturn vec2 out
+-- @treturn number length
 function vec2.normalized(a)
 	if a:is_zero() then
-		return new()
+		return new(), 0
 	end
-	return a:scale(1 / a:len())
+	local len = a:len()
+	return a:scale(1 / len), len
 end
 
 --- Trim a vector to a given length.
@@ -149,7 +151,8 @@ end
 -- @tparam number len Length to trim the vector to
 -- @treturn vec2 out
 function vec2.trim(a, len)
-	return a:normalized():scale(math.min(a:len(), len))
+	local u, a_len = a:normalized()
+	return u:scale(math.min(a_len, len))
 end
 
 --- Get the cross product of two vectors.

--- a/modules/vec2.lua
+++ b/modules/vec2.lua
@@ -134,10 +134,10 @@ function vec2.div(a, b)
 	)
 end
 
---- Get the normal of a vector.
+--- Get the unit vector for a vector.
 -- @tparam vec2 a Vector to normalize
 -- @treturn vec2 out
-function vec2.normalize(a)
+function vec2.normalized(a)
 	if a:is_zero() then
 		return new()
 	end
@@ -149,7 +149,7 @@ end
 -- @tparam number len Length to trim the vector to
 -- @treturn vec2 out
 function vec2.trim(a, len)
-	return a:normalize():scale(math.min(a:len(), len))
+	return a:normalized():scale(math.min(a:len(), len))
 end
 
 --- Get the cross product of two vectors.

--- a/modules/vec3.lua
+++ b/modules/vec3.lua
@@ -133,14 +133,16 @@ function vec3.div(a, b)
 	)
 end
 
---- Get the unit vector for a vector.
+--- Get the unit vector and length for a vector.
 -- @tparam vec3 a Vector to normalize
 -- @treturn vec3 out
+-- @treturn number length
 function vec3.normalized(a)
 	if a:is_zero() then
-		return new()
+		return new(), 0
 	end
-	return a:scale(1 / a:len())
+	local len = a:len()
+	return a:scale(1 / len), len
 end
 
 --- Trim a vector to a given length
@@ -148,7 +150,8 @@ end
 -- @tparam number len Length to trim the vector to
 -- @treturn vec3 out
 function vec3.trim(a, len)
-	return a:normalized():scale(math.min(a:len(), len))
+	local u, a_len = a:normalized()
+	return u:scale(math.min(a_len, len))
 end
 
 --- Get the cross product of two vectors.

--- a/modules/vec3.lua
+++ b/modules/vec3.lua
@@ -133,10 +133,10 @@ function vec3.div(a, b)
 	)
 end
 
---- Get the normal of a vector.
+--- Get the unit vector for a vector.
 -- @tparam vec3 a Vector to normalize
 -- @treturn vec3 out
-function vec3.normalize(a)
+function vec3.normalized(a)
 	if a:is_zero() then
 		return new()
 	end
@@ -148,7 +148,7 @@ end
 -- @tparam number len Length to trim the vector to
 -- @treturn vec3 out
 function vec3.trim(a, len)
-	return a:normalize():scale(math.min(a:len(), len))
+	return a:normalized():scale(math.min(a:len(), len))
 end
 
 --- Get the cross product of two vectors.
@@ -232,7 +232,7 @@ function vec3.rotate(a, phi, axis)
 		return a
 	end
 
-	local u = axis:normalize()
+	local u = axis:normalized()
 	local c = cos(phi)
 	local s = sin(phi)
 

--- a/spec/mat4_spec.lua
+++ b/spec/mat4_spec.lua
@@ -289,7 +289,7 @@ describe("mat4:", function()
 
 	it("reflects a matrix along a plane", function()
 		local origin = vec3(5, 1, 0)
-		local normal = vec3(0, -1, 0):normalize()
+		local normal = vec3(0, -1, 0):normalized()
 		local a = mat4():reflect(mat4(), origin, normal)
 		local p = a * vec3(-5, 2, 5)
 		assert.is.equal(p.x, -5)

--- a/spec/quat_spec.lua
+++ b/spec/quat_spec.lua
@@ -41,7 +41,7 @@ describe("quat:", function()
 	end)
 
 	it("creates a quaternion from a direction", function()
-		local v = vec3(-80, 80, -80):normalize()
+		local v = vec3(-80, 80, -80):normalized()
 		local a = quat.from_direction(v, vec3.unit_z)
 		assert.is_true(utils.tolerance(-0.577-a.x, 0.001))
 		assert.is_true(utils.tolerance(-0.577-a.y, 0.001))
@@ -127,8 +127,8 @@ describe("quat:", function()
 	end)
 
 	it("verifies quat composition order", function()
-		local a = quat(2, 3, 4, 1):normalize() -- Only the normal quaternions represent rotations
-		local b = quat(3, 6, 9, 1):normalize()
+		local a = quat(2, 3, 4, 1):normalized() -- Only the normal quaternions represent rotations
+		local b = quat(3, 6, 9, 1):normalized()
 		local c = a * b
 
 		local v = vec3(3, 4, 5)
@@ -140,7 +140,7 @@ describe("quat:", function()
 	end)
 
 	it("multiplies a quaternion by an exponent of 0", function()
-		local a = quat(2, 3, 4, 1):normalize()
+		local a = quat(2, 3, 4, 1):normalized()
 		local e = 0
 		local b = a:pow(e)
 		local c = a^e
@@ -153,7 +153,7 @@ describe("quat:", function()
 	end)
 
 	it("multiplies a quaternion by a positive exponent", function()
-		local a = quat(2, 3, 4, 1):normalize()
+		local a = quat(2, 3, 4, 1):normalized()
 		local e = 0.75
 		local b = a:pow(e)
 		local c = a^e
@@ -166,7 +166,7 @@ describe("quat:", function()
 	end)
 
 	it("multiplies a quaternion by a negative exponent", function()
-		local a = quat(2, 3, 4, 1):normalize()
+		local a = quat(2, 3, 4, 1):normalized()
 		local e = -1
 		local b = a:pow(e)
 		local c = a^e
@@ -187,7 +187,7 @@ describe("quat:", function()
 	end)
 
 	it("normalizes a quaternion", function()
-		local a = quat(1, 1, 1, 1):normalize()
+		local a = quat(1, 1, 1, 1):normalized()
 		assert.is.equal(0.5, a.x)
 		assert.is.equal(0.5, a.y)
 		assert.is.equal(0.5, a.z)

--- a/spec/vec2_spec.lua
+++ b/spec/vec2_spec.lua
@@ -111,7 +111,7 @@ describe("vec2:", function()
 
 	it("normalizes a vector", function()
 		local a = vec2(3, 5)
-		local b = a:normalize()
+		local b = a:normalized()
 		assert.is_true(abs(b:len()-1) < DBL_EPSILON)
 		end)
 

--- a/spec/vec3_spec.lua
+++ b/spec/vec3_spec.lua
@@ -121,7 +121,7 @@ describe("vec3:", function()
 
 	it("normalizes a vector", function()
 		local a = vec3(3, 5, 7)
-		local b = a:normalize()
+		local b = a:normalized()
 		assert.is_true(abs(b:len()-1) < DBL_EPSILON)
 		end)
 


### PR DESCRIPTION
"normalize" implies a change to the input vector/quat, but instead we
 produce a normalized copy.

This is a breaking change, but is simple for clients to fix.

You often need the length when working with normalized values, so
 return it along with the unit vector. This could introduce issues with when calling normalize as an argument to a function or a table:

```lua
t = { v:normalized() }
assert(#t == 1) -- fails
```

Maybe you'd prefer a new function `normalized_len()`?