### PR TITLE
backtick * in readme so it isn't interpreted as md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ Clone the repository and require it, or if you prefer luarocks: `$ luarocks inst
 
 # Versions
 
-This library has a major compatibility break at version 1.0. Up to version 0.10, composition a*b means "apply b, then a" for quaternions and "apply a, then b" for matrices. Now as of version 1.0, the two are consistent and matrix a*b means "apply b, then a".
+This library has a major compatibility break at version 1.0. Up to version 0.10, composition `a*b` means "apply b, then a" for quaternions and "apply a, then b" for matrices. Now as of version 1.0, the two are consistent and matrix `a*b` means "apply b, then a".


### PR DESCRIPTION
Without this, the two `*`s are considered matching italic delimiters.